### PR TITLE
Fix bug with overwriting attr value with defaults

### DIFF
--- a/Resources/views/Form/div_layout.html.twig
+++ b/Resources/views/Form/div_layout.html.twig
@@ -34,7 +34,7 @@
                 "{{ day }}":   form_widget(form.day),
             })|raw }}
 
-            {% set attr = attr|merge({"size": 10}) %}
+            {% set attr = {"size": 10}|merge(attr) %}
             {% set id = "datepicker_" ~ id %}
             {% set full_name = "datepicker_" ~ full_name %}
             {{ block("hidden_widget") }}
@@ -63,10 +63,10 @@
 
 {% block genemu_jquerychosen_widget %}
 {% spaceless %}
-    {% set attr = attr|merge({
-        "data-placeholder": empty_value,
-        "class": "chzn-select"
-    }) %}
+    {% set attr = {
+            "data-placeholder": empty_value,
+            "class": "chzn-select"
+        }|merge(attr) %}
     {{ block("choice_widget") }}
 {% endspaceless %}
 {% endblock genemu_jquerychosen_widget %}


### PR DESCRIPTION
Merge overwrite existing value and should be used in other way for setting defaults. Check 
https://github.com/fabpot/Twig/issues/590
