### PR TITLE
Added a null CsrfProvider to stay compatible with symfony2 master

### DIFF
--- a/Resources/config/twig.xml
+++ b/Resources/config/twig.xml
@@ -7,6 +7,7 @@
     <services>
         <service id="genemu.twig.extension.form" class="Genemu\Bundle\FormBundle\Twig\Extension\FormExtension">
             <tag name="twig.extension" />
+            <argument>null</argument>
             <argument>%twig.form.resources%</argument>
         </service>
     </services>


### PR DESCRIPTION
Hi,

I think the bundle isn't compatible with symfony2 master since this commit :
https://github.com/symfony/symfony/commit/e1aced89fd0f036ee4fd448d17184c168f2c9ae0
