### PR TITLE
Allowing nonDocumentRoot location of app

### DIFF
--- a/Controller/ImageController.php
+++ b/Controller/ImageController.php
@@ -31,8 +31,8 @@ class ImageController extends Controller
      */
     public function changeAction(Request $request)
     {
-        $rootDir = $this->container->getParameter('genemu.form.file.root_dir');
-        $folder = $this->container->getParameter('genemu.form.file.folder');
+        $rootDir = rtrim($this->container->getParameter('genemu.form.file.root_dir'), '/\\') . DIRECTORY_SEPARATOR;
+        $folder = rtrim($this->container->getParameter('genemu.form.file.folder'), '/\\') . DIRECTORY_SEPARATOR;
 
         $file = $request->get('image');
         $handle = new Image($rootDir . $this->stripQueryString($file));

--- a/Resources/views/Form/jquery_layout.html.twig
+++ b/Resources/views/Form/jquery_layout.html.twig
@@ -392,6 +392,9 @@
         var $form = $field.closest('form');
         var $preview = $('#{{ id }}_img_preview');
         var $options = $('#{{ id }}_options');
+        // Base path for apps not on DocumentRoot
+        var $basePath = '{{ asset(configs.folder) }}';
+        $basePath = $basePath.substr(0, $basePath.length - '{{ configs.folder }}'.length);
 
         var $coords = {};
         var $crop = null;
@@ -408,8 +411,11 @@
             onComplete: function(event, queueID, fileObj, response, data) {
                 var $response = eval('(' + response + ')');
 
+                // add if and only if path is relative
+                if ($response.thumbnail.file.search(/^[/\\]/) < 0) {
+                    $response.thumbnail.file = $basePath + $response.thumbnail.file;
+                }
                 $field.val($response.file);
-
                 if ($response.result == '1') {
                     createCrop({
                         image: $response.image,
@@ -429,6 +435,10 @@
                 $crop.destroy();
             }
 
+            // add if and only if path is relative
+            if (data.thumbnail.file.search(/^[/\\]/) < 0) {
+                data.thumbnail.file = $basePath + data.thumbnail.file;
+            }
             var $img = new Image();
 
             $($img).load(function() {

--- a/Resources/views/Form/stylesheet_layout.html.twig
+++ b/Resources/views/Form/stylesheet_layout.html.twig
@@ -123,7 +123,7 @@
             background-position: -48px -24px;
         }
         #{{ id }}_options .loading {
-            background: #FFF url({{ asset('bundles/genemuform/images/ajax-loader.gif') }});
+            background: #FFF url({{ asset('bundles/genemuform/images/ajax-loader.gif') }}) no-repeat;
             padding: 6px 0;
             height: 11px;
         }


### PR DESCRIPTION
This commit allows to use ImageCrop for apps out of the DocumentRoot (/).

Signed-off-by: Adam Kusmierz kusmierz@gmail.com
