### PR TITLE
Fix listener

### DIFF
--- a/Form/Core/EventListener/FileListener.php
+++ b/Form/Core/EventListener/FileListener.php
@@ -52,6 +52,7 @@ class FileListener implements EventSubscriberInterface
             return;
         }
 
+        $return = null;
         if (true === $this->multiple) {
             $paths = explode(',', $data);
             $return = array();


### PR DESCRIPTION
If there are two JQueryFileType children on a single form, the form listener is added twice, the second call to bindNormData would generate a notice
