### PR TITLE
Small configuration loader fixes

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -97,7 +97,7 @@ class Configuration implements ConfigurationInterface
                                     });
                                 })
                             ->end()
-                            ->prototype('array')->end()
+                            ->prototype('scalar')->end()
                         ->end()
                         ->scalarNode('font_dir')
                             ->defaultValue('%kernel.root_dir%/../web/bundles/genemuform/fonts')
@@ -106,7 +106,7 @@ class Configuration implements ConfigurationInterface
                             ->defaultValue(
                                 array('akbar.ttf', 'brushcut.ttf', 'molten.ttf', 'planetbe.ttf', 'whoobub.ttf')
                             )
-                            ->prototype('array')->end()
+                            ->prototype('scalar')->end()
                         ->end()
                         ->scalarNode('background_color')->defaultValue('DDDDDD')->end()
                         ->scalarNode('border_color')->defaultValue('000000')->end()

--- a/DependencyInjection/GenemuFormExtension.php
+++ b/DependencyInjection/GenemuFormExtension.php
@@ -81,12 +81,12 @@ class GenemuFormExtension extends Extension
         }
         unset($configs['font_dir']);
 
-        $backgroundColor = preg_replace('/^[0-9A-Fa-f]/', '', $configs['background_color']);
+        $backgroundColor = preg_replace('/[^0-9A-Fa-f]/', '', $configs['background_color']);
         if (!in_array(strlen($backgroundColor), array(3, 6), true)) {
             $configs['background_color'] = 'DDDDDD';
         }
 
-        $borderColor = preg_replace('/^[0-9A-Fa-f]/', '', $configs['border_color']);
+        $borderColor = preg_replace('/[^0-9A-Fa-f]/', '', $configs['border_color']);
         if (!in_array(strlen($borderColor), array(3, 6), true)) {
             $configs['border_color'] = '000000';
         }


### PR DESCRIPTION
- wrong placement of dash in the regexps
- wrong prototype for configuration arrays
