### PR TITLE
Form Types getDefaultOptions and getAllowedOptionValues methods updated

### DIFF
--- a/Form/Core/Type/CaptchaType.php
+++ b/Form/Core/Type/CaptchaType.php
@@ -73,13 +73,13 @@ class CaptchaType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getDefaultOptions(array $options)
+    public function getDefaultOptions()
     {
         $defaultOptions = array_merge(array(
             'attr' => array(
                 'autocomplete' => 'off'
             )
-        ), $this->options);
+        ), $options);
 
         return array_replace_recursive($defaultOptions, $options);
     }

--- a/Form/Core/Type/PlainType.php
+++ b/Form/Core/Type/PlainType.php
@@ -18,7 +18,7 @@ class PlainType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getDefaultOptions(array $options)
+    public function getDefaultOptions()
     {
         $defaultOptions = array(
             'widget'  => 'field',

--- a/Form/Core/Type/ReCaptchaType.php
+++ b/Form/Core/Type/ReCaptchaType.php
@@ -77,10 +77,10 @@ class ReCaptchaType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getDefaultOptions(array $options)
+    public function getDefaultOptions()
     {
         $defaultOptions = array(
-            'configs' => array_merge($this->options, array(
+            'configs' => array_merge($options, array(
                 'lang' => \Locale::getDefault(),
             )),
             'validator' => array(

--- a/Form/Core/Type/TinymceType.php
+++ b/Form/Core/Type/TinymceType.php
@@ -56,10 +56,10 @@ class TinymceType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getDefaultOptions(array $options)
+    public function getDefaultOptions()
     {
         $defaultOptions = array(
-            'configs' => array_merge($this->options, array(
+            'configs' => array_merge($options, array(
                 'language' => \Locale::getDefault(),
             )),
             'required' => false,

--- a/Form/Doctrine/Type/AjaxEntityType.php
+++ b/Form/Doctrine/Type/AjaxEntityType.php
@@ -42,7 +42,7 @@ class AjaxEntityType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getDefaultOptions(array $options)
+    public function getDefaultOptions()
     {
         $defaultOptions = array(
             'em'            => null,

--- a/Form/JQuery/Type/AutocompleterType.php
+++ b/Form/JQuery/Type/AutocompleterType.php
@@ -74,7 +74,7 @@ class AutocompleterType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getDefaultOptions(array $options)
+    public function getDefaultOptions()
     {
         $defaultOptions = array(
             'widget' => 'choice',
@@ -95,7 +95,7 @@ class AutocompleterType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getAllowedOptionValues(array $options)
+    public function getAllowedOptionValues()
     {
         return array(
             'widget' => array(

--- a/Form/JQuery/Type/ChosenType.php
+++ b/Form/JQuery/Type/ChosenType.php
@@ -42,7 +42,7 @@ class ChosenType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getDefaultOptions(array $options)
+    public function getDefaultOptions()
     {
         $defaultOptions = array(
             'widget' => 'choice',
@@ -55,7 +55,7 @@ class ChosenType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getAllowedOptionValues(array $options)
+    public function getAllowedOptionValues()
     {
         return array(
             'widget' => array(

--- a/Form/JQuery/Type/ColorType.php
+++ b/Form/JQuery/Type/ColorType.php
@@ -47,7 +47,7 @@ class ColorType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getDefaultOptions(array $options)
+    public function getDefaultOptions()
     {
         $defaultOptions = array(
             'widget'  => 'field',
@@ -60,7 +60,7 @@ class ColorType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getAllowedOptionValues(array $options)
+    public function getAllowedOptionValues()
     {
         return array(
             'widget' => array(

--- a/Form/JQuery/Type/DateType.php
+++ b/Form/JQuery/Type/DateType.php
@@ -73,14 +73,14 @@ class DateType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getDefaultOptions(array $options)
+    public function getDefaultOptions()
     {
         $defaultOptions = array(
             'culture' => \Locale::getDefault(),
             'widget' => 'choice',
             'configs' => array_merge(array(
                 'dateFormat' => null,
-            ), $this->options),
+            ), $options),
         );
 
         $options = array_replace_recursive($defaultOptions, $options);

--- a/Form/JQuery/Type/FileType.php
+++ b/Form/JQuery/Type/FileType.php
@@ -104,7 +104,7 @@ class FileType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getDefaultOptions(array $options)
+    public function getDefaultOptions()
     {
         $defaultOptions = array(
             'required' => false,

--- a/Form/JQuery/Type/GeolocationType.php
+++ b/Form/JQuery/Type/GeolocationType.php
@@ -63,7 +63,7 @@ class GeolocationType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getDefaultOptions(array $options)
+    public function getDefaultOptions()
     {
         $defaultOptions = array(
             'map' => false,

--- a/Form/JQuery/Type/ImageType.php
+++ b/Form/JQuery/Type/ImageType.php
@@ -82,7 +82,7 @@ class ImageType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getDefaultOptions(array $options)
+    public function getDefaultOptions()
     {
         $defaultOptions = array(
             'configs' => array(

--- a/Form/JQuery/Type/RatingType.php
+++ b/Form/JQuery/Type/RatingType.php
@@ -43,7 +43,7 @@ class RatingType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getDefaultOptions(array $options)
+    public function getDefaultOptions()
     {
         $defaultOptions = array(
             'configs' => array(),

--- a/Form/JQuery/Type/SliderType.php
+++ b/Form/JQuery/Type/SliderType.php
@@ -49,7 +49,7 @@ class SliderType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getDefaultOptions(array $options)
+    public function getDefaultOptions()
     {
         $defaultOptions = array(
             'min' => 0,
@@ -64,7 +64,7 @@ class SliderType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getAllowedOptionValues(array $options)
+    public function getAllowedOptionValues()
     {
         return array(
             'orientation' => array(

--- a/Form/JQuery/Type/TokeninputType.php
+++ b/Form/JQuery/Type/TokeninputType.php
@@ -120,7 +120,7 @@ class TokeninputType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getDefaultOptions(array $options)
+    public function getDefaultOptions()
     {
         $defaultOptions = array(
             'widget' => 'choice',
@@ -145,7 +145,7 @@ class TokeninputType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getAllowedOptionValues(array $options)
+    public function getAllowedOptionValues()
     {
         return array(
             'widget' => array(

--- a/Form/Model/Type/AjaxModelType.php
+++ b/Form/Model/Type/AjaxModelType.php
@@ -28,7 +28,7 @@ class AjaxModelType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getDefaultOptions(array $options)
+    public function getDefaultOptions()
     {
         $defaultOptions = array(
             'template' => 'choice',


### PR DESCRIPTION
Bundle Form Types getDefaultOptions and getAllowedOptionValues methods seem to be incompatible with Symfony FormTypeInterface.

Indeed no options argument has to be passed to the method.

Here is the returned error:
Fatal error: Declaration of Genemu\Bundle\FormBundle\Form\Core\Type\ReCaptchaType::getDefaultOptions() must be compatible with that of Symfony\Component\Form\FormTypeInterface::getDefaultOptions() [...]

Waiting for your opinion about it.
