### PR TITLE
New Form Types getDefaultOptions and getAllowedOptionValues methods

### DIFF
--- a/Form/Core/Type/CaptchaType.php
+++ b/Form/Core/Type/CaptchaType.php
@@ -75,13 +75,11 @@ class CaptchaType extends AbstractType
      */
     public function getDefaultOptions()
     {
-        $defaultOptions = array_merge(array(
+        return array_merge(array(
             'attr' => array(
                 'autocomplete' => 'off'
             )
         ), $this->options);
-
-        return array_replace_recursive($defaultOptions, $options);
     }
 
     /**

--- a/Form/Core/Type/PlainType.php
+++ b/Form/Core/Type/PlainType.php
@@ -20,7 +20,7 @@ class PlainType extends AbstractType
      */
     public function getDefaultOptions()
     {
-        $defaultOptions = array(
+        return array(
             'widget'  => 'field',
             'configs' => array(),
             'read_only' => true,
@@ -29,8 +29,6 @@ class PlainType extends AbstractType
             )
             //'property_path' => false,
         );
-
-        return array_replace_recursive($defaultOptions, $options);
     }
 
     /**

--- a/Form/Core/Type/ReCaptchaType.php
+++ b/Form/Core/Type/ReCaptchaType.php
@@ -55,7 +55,7 @@ class ReCaptchaType extends AbstractType
      */
     public function buildForm(FormBuilder $builder, array $options)
     {
-        $options = $this->getDefaultOptions($options);
+        $options = $this->getDefaultOptions();
 
         $builder
             ->addValidator($this->validator)
@@ -79,7 +79,7 @@ class ReCaptchaType extends AbstractType
      */
     public function getDefaultOptions()
     {
-        $defaultOptions = array(
+        return array(
             'configs' => array_merge($this->options, array(
                 'lang' => \Locale::getDefault(),
             )),
@@ -91,8 +91,6 @@ class ReCaptchaType extends AbstractType
             ),
             'error_bubbling' => false,
         );
-
-        return array_replace_recursive($defaultOptions, $options);
     }
 
     /**

--- a/Form/Core/Type/TinymceType.php
+++ b/Form/Core/Type/TinymceType.php
@@ -40,7 +40,7 @@ class TinymceType extends AbstractType
      */
     public function buildForm(FormBuilder $builder, array $options)
     {
-        $options = $this->getDefaultOptions($options);
+        $options = $this->getDefaultOptions();
 
         $builder->setAttribute('configs', $options['configs']);
     }
@@ -58,14 +58,12 @@ class TinymceType extends AbstractType
      */
     public function getDefaultOptions()
     {
-        $defaultOptions = array(
+        return array(
             'configs' => array_merge($this->options, array(
                 'language' => \Locale::getDefault(),
             )),
             'required' => false,
         );
-
-        return array_replace_recursive($defaultOptions, $options);
     }
 
     /**

--- a/Form/Doctrine/Type/AjaxEntityType.php
+++ b/Form/Doctrine/Type/AjaxEntityType.php
@@ -15,6 +15,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\Options;
 
 use Doctrine\Common\Persistence\ManagerRegistry;
 
@@ -44,26 +45,30 @@ class AjaxEntityType extends AbstractType
      */
     public function getDefaultOptions()
     {
-        $defaultOptions = array(
+        $options = array(
             'em'            => null,
             'class'         => null,
             'property'      => null,
             'query_builder' => null,
             'choices'       => null,
             'group_by'      => null,
-            'ajax'          => false
-        );
+            'ajax'          => false,
+            'choice_list'   => function (Options $options, $previousValue) {
+                if (null === $previousValue)
+                {
+                    return new AjaxEntityChoiceList(
+                        $this->registry->getManager($options['em']),
+                        $options['class'],
+                        $options['property'],
+                        $options['query_builder'],
+                        $options['choices'],
+                        $options['group_by'],
+                        $options['ajax']
+                    );
+                }
 
-        $options = array_replace($defaultOptions, $options);
-
-        $options['choice_list'] = new AjaxEntityChoiceList(
-            $this->registry->getManager($options['em']),
-            $options['class'],
-            $options['property'],
-            $options['query_builder'],
-            $options['choices'],
-            $options['group_by'],
-            $options['ajax']
+                return null;
+            }
         );
 
         return $options;

--- a/Form/JQuery/Type/AutocompleterType.php
+++ b/Form/JQuery/Type/AutocompleterType.php
@@ -76,18 +76,21 @@ class AutocompleterType extends AbstractType
      */
     public function getDefaultOptions()
     {
-        $defaultOptions = array(
+        $options = array(
             'widget' => 'choice',
             'route_name' => null,
-            'ajax' => false,
+            'ajax' => function (Options $options, $previousValue) {
+                if (null === $previousValue) {
+                    if (!empty($options['route_name']))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            },
             'freeValues' => false,
         );
-
-        $options = array_replace($defaultOptions, $options);
-
-        if (!empty($options['route_name'])) {
-            $options['ajax'] = true;
-        }
 
         return $options;
     }

--- a/Form/JQuery/Type/ChosenType.php
+++ b/Form/JQuery/Type/ChosenType.php
@@ -44,12 +44,10 @@ class ChosenType extends AbstractType
      */
     public function getDefaultOptions()
     {
-        $defaultOptions = array(
+        return array(
             'widget' => 'choice',
             'allow_single_deselect' => true,
         );
-
-        return array_replace($defaultOptions, $options);
     }
 
     /**

--- a/Form/JQuery/Type/ColorType.php
+++ b/Form/JQuery/Type/ColorType.php
@@ -49,12 +49,10 @@ class ColorType extends AbstractType
      */
     public function getDefaultOptions()
     {
-        $defaultOptions = array(
+        return array(
             'widget'  => 'field',
             'configs' => array(),
         );
-
-        return array_replace($defaultOptions, $options);
     }
 
     /**

--- a/Form/JQuery/Type/DateType.php
+++ b/Form/JQuery/Type/DateType.php
@@ -40,7 +40,7 @@ class DateType extends AbstractType
      */
     public function buildForm(FormBuilder $builder, array $options)
     {
-        $options = $this->getDefaultOptions($options);
+        $options = $this->getDefaultOptions();
 
         $builder
             ->setAttribute('years', $options['years'])
@@ -75,19 +75,24 @@ class DateType extends AbstractType
      */
     public function getDefaultOptions()
     {
-        $defaultOptions = array(
+        $options = array(
             'culture' => \Locale::getDefault(),
             'widget' => 'choice',
             'configs' => array_merge(array(
                 'dateFormat' => null,
+                'showOn' => function (Options $options, $previousValue) {
+                    if (null === $previousValue)
+                    {
+                        if ('single_text' !== $options['widget'] || isset($options['configs']['buttonImage']))
+                        {
+                            return 'button';
+                        }
+                    }
+
+                    return null;
+                }
             ), $this->options),
         );
-
-        $options = array_replace_recursive($defaultOptions, $options);
-
-        if ('single_text' !== $options['widget'] || isset($options['configs']['buttonImage'])) {
-            $options['configs']['showOn'] = 'button';
-        }
 
         return $options;
     }

--- a/Form/JQuery/Type/FileType.php
+++ b/Form/JQuery/Type/FileType.php
@@ -106,13 +106,11 @@ class FileType extends AbstractType
      */
     public function getDefaultOptions()
     {
-        $defaultOptions = array(
+        return array(
             'required' => false,
             'multiple' => false,
             'configs' => array(),
         );
-
-        return array_replace($defaultOptions, $options);
     }
 
     /**

--- a/Form/JQuery/Type/GeolocationType.php
+++ b/Form/JQuery/Type/GeolocationType.php
@@ -65,7 +65,7 @@ class GeolocationType extends AbstractType
      */
     public function getDefaultOptions()
     {
-        $defaultOptions = array(
+        return array(
             'map' => false,
             'latitude' => array(
                 'enabled' => false,
@@ -84,8 +84,6 @@ class GeolocationType extends AbstractType
                 'hidden' => false,
             ),
         );
-
-        return array_replace($defaultOptions, $options);
     }
 
     /**

--- a/Form/JQuery/Type/ImageType.php
+++ b/Form/JQuery/Type/ImageType.php
@@ -84,14 +84,12 @@ class ImageType extends AbstractType
      */
     public function getDefaultOptions()
     {
-        $defaultOptions = array(
+        return array(
             'configs' => array(
                 'fileExt' => '*.jpg;*.gif;*.png;*.jpeg',
                 'fileDesc' => 'Web Image Files (.jpg, .gif, .png, .jpeg)',
             )
         );
-
-        return array_replace_recursive($defaultOptions, $options);
     }
 
     /**

--- a/Form/JQuery/Type/RatingType.php
+++ b/Form/JQuery/Type/RatingType.php
@@ -15,6 +15,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\Options;
 
 /**
  * RatingType
@@ -45,15 +46,21 @@ class RatingType extends AbstractType
      */
     public function getDefaultOptions()
     {
-        $defaultOptions = array(
-            'configs' => array(),
+        $options = array(
+            'configs' => function (Options $options, $previousValue) {
+                $configs = array();
+
+                if (null === $previousValue)
+                {
+                    if (!isset($options['expanded']) || (isset($options['examded']) && !$options['expanded']))
+                    {
+                        $configs['inputType'] = 'select';
+                    }
+                }
+
+                return $configs;
+            }
         );
-
-        $options = array_replace($defaultOptions, $options);
-
-        if (!isset($options['expanded']) || (isset($options['examded']) && !$options['expanded'])) {
-            $options['configs']['inputType'] = 'select';
-        }
 
         return $options;
     }

--- a/Form/JQuery/Type/SliderType.php
+++ b/Form/JQuery/Type/SliderType.php
@@ -51,14 +51,12 @@ class SliderType extends AbstractType
      */
     public function getDefaultOptions()
     {
-        $defaultOptions = array(
+        return array(
             'min' => 0,
             'max' => 100,
             'step' => 1,
             'orientation' => 'horizontal'
         );
-
-        return array_replace($defaultOptions, $options);
     }
 
     /**

--- a/Form/JQuery/Type/TokeninputType.php
+++ b/Form/JQuery/Type/TokeninputType.php
@@ -122,22 +122,26 @@ class TokeninputType extends AbstractType
      */
     public function getDefaultOptions()
     {
-        $defaultOptions = array(
+        $options = array(
             'widget' => 'choice',
             'route_name' => null,
-            'ajax' => false,
+            'ajax' => function (Options $options, $previousValue) {
+                if (null === $previousValue)
+                {
+                    if (false === empty($options['route_name']))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            },
             'queryParam' => 'term',
             'preventDuplicates' => true,
             'tokenValue' => 'value',
             'propertyToSearch' => 'label',
             'theme' => 'facebook'
         );
-
-        if (false === empty($options['route_name'])) {
-            $options['ajax'] = true;
-        }
-
-        $options = array_replace($defaultOptions, $options);
 
         return $options;
     }

--- a/Form/Model/Type/AjaxModelType.php
+++ b/Form/Model/Type/AjaxModelType.php
@@ -30,29 +30,34 @@ class AjaxModelType extends AbstractType
      */
     public function getDefaultOptions()
     {
-        $defaultOptions = array(
-            'template' => 'choice',
-            'multiple' => false,
-            'expanded' => false,
-            'class' => null,
-            'property' => null,
-            'query' => null,
-            'choices' => array(),
+        $options = array(
+            'template'          => 'choice',
+            'multiple'          => false,
+            'expanded'          => false,
+            'class'             => null,
+            'property'          => null,
+            'query'             => null,
+            'choices'           => array(),
             'preferred_choices' => array(),
-            'ajax' => false,
+            'ajax'              => false,
+            'choice_list'       => function (Options $options, $previousValue) {
+                if (null === $previousValue)
+                {
+                    if (!isset($options['choice_list']))
+                    {
+                        return new AjaxModelChoiceList(
+                            $options['class'],
+                            $options['property'],
+                            $options['choices'],
+                            $options['query'],
+                            $options['ajax']
+                        );
+                    }
+                }
+
+                return null;
+            }
         );
-
-        $options = array_replace($defaultOptions, $options);
-
-        if (!isset($options['choice_list'])) {
-            $options['choice_list'] = new AjaxModelChoiceList(
-                $options['class'],
-                $options['property'],
-                $options['choices'],
-                $options['query'],
-                $options['ajax']
-            );
-        }
 
         return $options;
     }


### PR DESCRIPTION
Symfony Form Types has been updated few days ago (https://github.com/symfony/symfony/commit/b7330456b698f7dd10bd2171c7075fc34c13858e#diff-6).

GemenuFormBundle Form Types getDefaultOptions and getAllowedOptionValues methods are incompatible with new Symfony FormTypeInterface (no options argument has to be passed to the method).

Here is an example of returned error:
Fatal error: Declaration of Genemu\Bundle\FormBundle\Form\Core\Type\ReCaptchaType::getDefaultOptions() must be compatible with that of Symfony\Component\Form\FormTypeInterface::getDefaultOptions() [...]

I've tried to fix this problem and I'm waiting for your opinion and ideas about it.

Thanks!
