### PR TITLE
Try to have the culture closer from the jQuery i18n bad culture formats

### DIFF
--- a/Form/JQuery/Type/DateType.php
+++ b/Form/JQuery/Type/DateType.php
@@ -64,12 +64,14 @@ class DateType extends AbstractType
                 $configs['dateFormat'] = $this->getJavascriptPattern($formatter);
             }
         }
+        
+        $culture = str_replace('_', '-', $form->getAttribute('culture'));
 
         $view
             ->set('min_year', min($year))
             ->set('max_year', max($year))
             ->set('configs', $configs)
-            ->set('culture', $form->getAttribute('culture'));
+            ->set('culture', $culture);
     }
 
     /**


### PR DESCRIPTION
The cultures in jQuery UI i18n are bad and inconsistent : http://jquery-ui.googlecode.com/svn/trunk/ui/i18n/

When you have an `fr_BE` culture set in Symfony2, you will not match any of the provided files... (and I can't came around with an elegant fix for that).

The aim of this patch is only to enable matching for the `en_GB` culture, because jQuery name it `en-GB` (there is some others in this case).
