### PR TITLE
Travis UI and some unit tests fix for 2.0 version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,16 @@ php:
     - 5.4
 
 env:
-    - SYMFONY_VERSION=v2.0.6
+    - SYMFONY_VERSION=v2.0.8
 
 before_script:
     - sh -c "psql -c 'create database test;' -U postgres;"
     - mongo test --eval 'db.addUser("travis", "test");'
-    - php vendor/vendors.php
+    - php vendor/vendors.php install
+    - pecl install mongo
+    - echo "extension=mongo.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"`
 
-script: rake test
+script: phpunit
 
 notifications:
   email: travis-ci@generation-multiple.com

--- a/Form/JQuery/Type/FileType.php
+++ b/Form/JQuery/Type/FileType.php
@@ -83,7 +83,7 @@ class FileType extends AbstractType
                         $data = new File($form->getAttribute('rootDir') . '/' . $data);
                     }
 
-                    if ($configs['custom_storage_folder']){
+                    if (isset($configs['custom_storage_folder']) && $configs['custom_storage_folder']){
                         $value[] = $form->getClientData();
                     }else{
                         $value[] = $configs['folder'] . '/' . $data->getFilename();
@@ -97,7 +97,7 @@ class FileType extends AbstractType
                     $datas = new File($form->getAttribute('rootDir') . '/' . $datas);
                 }
 
-                if (($configs['custom_storage_folder']) && (false === ($value = $form->getClientData())instanceof File)){
+                if (isset($configs['custom_storage_folder']) && $configs['custom_storage_folder'] && (false === ($value = $form->getClientData())instanceof File)){
                     // This if will be executed only when we load entity with existing file pointed to the folder different
                     // from $configs['folder']
                 }else{

--- a/Form/JQuery/Type/ImageType.php
+++ b/Form/JQuery/Type/ImageType.php
@@ -72,10 +72,10 @@ class ImageType extends AbstractType
                     ));
             }
 
-            if (($configs['custom_storage_folder']) && (false === ($value = $form->getClientData())instanceof File)){
+            if (isset($configs['custom_storage_folder']) && $configs['custom_storage_folder'] && (false === ($value = $form->getClientData())instanceof File)){
                 // This if will be executed only when we load entity with existing file pointed to the folder different
                 // from $configs['folder']
-            }else{
+            } else {
                 $value = $configs['folder'] . '/' . $data->getFilename();
             }
 

--- a/Tests/Form/Type/CaptchaTypeTest.php
+++ b/Tests/Form/Type/CaptchaTypeTest.php
@@ -22,8 +22,8 @@ class CaptchaTypeTest extends TypeTestCase
     {
         parent::setUp();
 
-        if (!function_exists('gd_info')) {
-            $this->markTestSkipped('Gd not installed');
+        if (!function_exists('gd_info') || !function_exists('imagettfbbox')) {
+            $this->markTestSkipped('Gd with freetype not installed');
         }
     }
 

--- a/Tests/Form/Type/JQuery/FileTypeTest.php
+++ b/Tests/Form/Type/JQuery/FileTypeTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Genemu\Bundle\FormBundle\Tests\Form\Type;
+namespace Genemu\Bundle\FormBundle\Tests\Form\Type\JQuery;
 
 use Symfony\Component\HttpFoundation\File\File;
 

--- a/Tests/Gd/File/ImageTest.php
+++ b/Tests/Gd/File/ImageTest.php
@@ -14,20 +14,13 @@ namespace Genemu\Bundle\FormBundle\Tests\Gd\File;
 use Genemu\Bundle\FormBundle\Gd\File\Image;
 use Genemu\Bundle\FormBundle\Gd\Filter\Background;
 
+use Genemu\Bundle\FormBundle\Tests\Gd\TestCase;
+
 /**
  * @author Olivier Chauvel <olivier@generation-multiple.com>
  */
-class ImageTest extends \PHPUnit_Framework_TestCase
+class ImageTest extends TestCase
 {
-    public function setUp()
-    {
-        parent::setUp();
-
-        if (!function_exists('gd_info')) {
-            $this->markTestSkipped('Gd not installed');
-        }
-    }
-
     public function testImage()
     {
         $image = new Image(__DIR__ . '/../../Fixtures/upload/symfony.png');

--- a/Tests/Gd/Filter/BackgroundTest.php
+++ b/Tests/Gd/Filter/BackgroundTest.php
@@ -12,21 +12,13 @@
 namespace Genemu\Bundle\FormBundle\Tests\Gd\Filter;
 
 use Genemu\Bundle\FormBundle\Gd\Filter\Background;
+use Genemu\Bundle\FormBundle\Tests\Gd\TestCase;
 
 /**
  * @author Olivier Chauvel <olivier@generation-multiple.com>
  */
-class BackgroundTest extends \PHPUnit_Framework_TestCase
+class BackgroundTest extends TestCase
 {
-    public function setUp()
-    {
-        parent::setUp();
-
-        if (!function_exists('gd_info')) {
-            $this->markTestSkipped('Gd not installed');
-        }
-    }
-
     public function testBackground()
     {
         $filter = new Background('#FFF');

--- a/Tests/Gd/Filter/BorderTest.php
+++ b/Tests/Gd/Filter/BorderTest.php
@@ -12,21 +12,13 @@
 namespace Genemu\Bundle\FormBundle\Tests\Gd\Filter;
 
 use Genemu\Bundle\FormBundle\Gd\Filter\Border;
+use Genemu\Bundle\FormBundle\Tests\Gd\TestCase;
 
 /**
  * @author Olivier Chauvel <olivier@generation-multiple.com>
  */
-class BorderTest extends \PHPUnit_Framework_TestCase
+class BorderTest extends TestCase
 {
-    public function setUp()
-    {
-        parent::setUp();
-
-        if (!function_exists('gd_info')) {
-            $this->markTestSkipped('Gd not installed');
-        }
-    }
-
     public function testDefault()
     {
         $filter = new Border('#FFF');

--- a/Tests/Gd/Filter/ColorizeTest.php
+++ b/Tests/Gd/Filter/ColorizeTest.php
@@ -12,21 +12,13 @@
 namespace Genemu\Bundle\FormBundle\Tests\Gd\Filter;
 
 use Genemu\Bundle\FormBundle\Gd\Filter\Colorize;
+use Genemu\Bundle\FormBundle\Tests\Gd\TestCase;
 
 /**
  * @author Olivier Chauvel <olivier@generation-multiple.com>
  */
-class ColorizeTest extends \PHPUnit_Framework_TestCase
+class ColorizeTest extends TestCase
 {
-    public function setUp()
-    {
-        parent::setUp();
-
-        if (!function_exists('gd_info')) {
-            $this->markTestSkipped('Gd not installed');
-        }
-    }
-
     public function testDefault()
     {
         $filter = new Colorize('#000');

--- a/Tests/Gd/Filter/CropTest.php
+++ b/Tests/Gd/Filter/CropTest.php
@@ -12,21 +12,13 @@
 namespace Genemu\Bundle\FormBundle\Tests\Gd\Filter;
 
 use Genemu\Bundle\FormBundle\Gd\Filter\Crop;
+use Genemu\Bundle\FormBundle\Tests\Gd\TestCase;
 
 /**
  * @author Olivier Chauvel <olivier@generation-multiple.com>
  */
-class CropTest extends \PHPUnit_Framework_TestCase
+class CropTest extends TestCase
 {
-    public function setUp()
-    {
-        parent::setUp();
-
-        if (!function_exists('gd_info')) {
-            $this->markTestSkipped('Gd not installed');
-        }
-    }
-
     public function testDefault()
     {
         $filter = new Crop(0, 0, 5, 5);

--- a/Tests/Gd/Filter/GrayScaleTest.php
+++ b/Tests/Gd/Filter/GrayScaleTest.php
@@ -12,21 +12,13 @@
 namespace Genemu\Bundle\FormBundle\Tests\Gd\Filter;
 
 use Genemu\Bundle\FormBundle\Gd\Filter\GrayScale;
+use Genemu\Bundle\FormBundle\Tests\Gd\TestCase;
 
 /**
  * @author Olivier Chauvel <olivier@generation-multiple.com>
  */
-class GrayScaleTest extends \PHPUnit_Framework_TestCase
+class GrayScaleTest extends TestCase
 {
-    public function setUp()
-    {
-        parent::setUp();
-
-        if (!function_exists('gd_info')) {
-            $this->markTestSkipped('Gd not installed');
-        }
-    }
-
     public function testDefault()
     {
         $filter = new GrayScale();

--- a/Tests/Gd/Filter/NegateTest.php
+++ b/Tests/Gd/Filter/NegateTest.php
@@ -12,21 +12,13 @@
 namespace Genemu\Bundle\FormBundle\Tests\Gd\Filter;
 
 use Genemu\Bundle\FormBundle\Gd\Filter\Negate;
+use Genemu\Bundle\FormBundle\Tests\Gd\TestCase;
 
 /**
  * @author Olivier Chauvel <olivier@generation-multiple.com>
  */
-class NegateTest extends \PHPUnit_Framework_TestCase
+class NegateTest extends TestCase
 {
-    public function setUp()
-    {
-        parent::setUp();
-
-        if (!function_exists('gd_info')) {
-            $this->markTestSkipped('Gd not installed');
-        }
-    }
-
     public function testDefault()
     {
         $filter = new Negate();

--- a/Tests/Gd/Filter/RotateTest.php
+++ b/Tests/Gd/Filter/RotateTest.php
@@ -12,21 +12,13 @@
 namespace Genemu\Bundle\FormBundle\Tests\Gd\Filter;
 
 use Genemu\Bundle\FormBundle\Gd\Filter\Rotate;
+use Genemu\Bundle\FormBundle\Tests\Gd\TestCase;
 
 /**
  * @author Olivier Chauvel <olivier@generation-multiple.com>
  */
-class RotateTest extends \PHPUnit_Framework_TestCase
+class RotateTest extends TestCase
 {
-    public function setUp()
-    {
-        parent::setUp();
-
-        if (!function_exists('gd_info')) {
-            $this->markTestSkipped('Gd not installed');
-        }
-    }
-
     public function testDefault()
     {
         $filter = new Rotate(10);

--- a/Tests/Gd/Filter/StripTest.php
+++ b/Tests/Gd/Filter/StripTest.php
@@ -12,21 +12,13 @@
 namespace Genemu\Bundle\FormBundle\Tests\Gd\Filter;
 
 use Genemu\Bundle\FormBundle\Gd\Filter\Strip;
+use Genemu\Bundle\FormBundle\Tests\Gd\TestCase;
 
 /**
  * @author Olivier Chauvel <olivier@generation-multiple.com>
  */
-class StripTest extends \PHPUnit_Framework_TestCase
+class StripTest extends TestCase
 {
-    public function setUp()
-    {
-        parent::setUp();
-
-        if (!function_exists('gd_info')) {
-            $this->markTestSkipped('Gd not installed');
-        }
-    }
-
     public function testDefault()
     {
         $filter = new Strip(array('000', 'FFFFFF'));

--- a/Tests/Gd/Filter/TextTest.php
+++ b/Tests/Gd/Filter/TextTest.php
@@ -14,21 +14,13 @@ namespace Genemu\Bundle\FormBundle\Tests\Gd\Filter;
 use Symfony\Component\HttpFoundation\File\File;
 
 use Genemu\Bundle\FormBundle\Gd\Filter\Text;
+use Genemu\Bundle\FormBundle\Tests\Gd\TestCase;
 
 /**
  * @author Olivier Chauvel <olivier@generation-multiple.com>
  */
-class TextTest extends \PHPUnit_Framework_TestCase
+class TextTest extends TestCase
 {
-    public function setUp()
-    {
-        parent::setUp();
-
-        if (!function_exists('gd_info')) {
-            $this->markTestSkipped('Gd not installed');
-        }
-    }
-
     public function testDefault()
     {
         $filter = new Text('Foo', 12, array(new File(__DIR__ . '/../../Fixtures/fonts/akbar.ttf')), array('000'));

--- a/Tests/Gd/GdTest.php
+++ b/Tests/Gd/GdTest.php
@@ -16,17 +16,8 @@ use Genemu\Bundle\FormBundle\Gd\Gd;
 /**
  * @author Olivier Chauvel <olivier@generation-multiple.com>
  */
-class GdTest extends \PHPUnit_Framework_TestCase
+class GdTest extends TestCase
 {
-    public function setUp()
-    {
-        parent::setUp();
-
-        if (!function_exists('gd_info')) {
-            $this->markTestSkipped('Gd not installed');
-        }
-    }
-
     public function testHexToSimpleColor()
     {
         $gd = new Gd();

--- a/Tests/Gd/TestCase.php
+++ b/Tests/Gd/TestCase.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Olivier Chauvel <olivier@generation-multiple.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Genemu\Bundle\FormBundle\Tests\Gd;
+
+/**
+ * @author Leszek Prabucki <leszek.prabucki@gmail.com>
+ */
+class TestCase extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        if (!function_exists('gd_info') || !function_exists('imagettfbbox')) {
+
+            $this->markTestSkipped('Gd with freetype not installed');
+        }
+    }
+}

--- a/vendor/vendors.php
+++ b/vendor/vendors.php
@@ -23,7 +23,7 @@ $deps = array(
     array('doctrine-dbal', 'git://github.com/doctrine/dbal.git', 'origin/master'),
     array('doctrine-mongodb', 'git://github.com/doctrine/mongodb.git', 'origin/master'),
     array('doctrine-mongodb-odm', 'git://github.com/doctrine/mongodb-odm.git', 'origin/master'),
-    array('bundles/Symfony/Bundle/DoctrineMongoDBBundle', 'git://github.com/symfony/DoctrineMongoDBBundle.git', 'origin/2.0'),
+    array('bundles/Symfony/Bundle/DoctrineMongoDBBundle', 'git://github.com/doctrine/DoctrineMongoDBBundle.git', 'origin/2.0'),
 );
 
 foreach ($deps as $dep) {


### PR DESCRIPTION
- Return script execution status for travis execution (so will be notified when something fail) - move stuff from Rakefile into .travis.yml
- DoctrineBundle repo was moved to doctrine repos.
- Fixed vendor/vendors.php script
- Skip GD tests when gd with freetype is not instaled
- Fixed notices and warning in form types

Travis CI status: [![Build Status](https://secure.travis-ci.org/l3l0/GenemuFormBundle.png?branch=fix-tests)](http://travis-ci.org/l3l0/GenemuFormBundle)
