### PR TITLE
Fix chosen type test

### DIFF
--- a/Tests/Form/JQuery/Type/ChosenTypeTest.php
+++ b/Tests/Form/JQuery/Type/ChosenTypeTest.php
@@ -32,6 +32,9 @@ class ChosenTypeTest extends TypeTestCase
     {
         $form = $this->factory->create(new ChosenType('country'));
 
-        $this->assertContains('country', $form->getConfig()->getType()->getName());
+        $this->assertEquals(
+            'country',
+            $form->getConfig()->getType()->getParent()->getName()
+        );
     }
 }


### PR DESCRIPTION
The chosen type test is currently out of sync with the Symfony Form Component. This PR fixes that.
