### PR TITLE
Removed normalizer from ChosenType

### DIFF
--- a/Form/JQuery/Type/ChosenType.php
+++ b/Form/JQuery/Type/ChosenType.php
@@ -61,11 +61,6 @@ class ChosenType extends AbstractType
                 'allow_single_deselect' => true,
                 'disable_search_threshold' => 0
             ))
-            ->setNormalizers(array(
-                'expanded' => function (Options $options) {
-                    return false;
-                }
-            ))
         ;
     }
 


### PR DESCRIPTION
This fixes the functionality of ChosenType when passing the `expanded` option.
Can you spot any side effects of this change? Not really sure why this was always returning false.

Thanks
