### PR TITLE
Updated DoctrineMongoDBBundle service IDs

### DIFF
--- a/Resources/config/mongodb.xml
+++ b/Resources/config/mongodb.xml
@@ -7,7 +7,7 @@
     <services>
         <service id="genemu.form.document.type.ajaxdocument" class="Genemu\Bundle\FormBundle\Form\Doctrine\Type\AjaxDocumentType">
             <tag name="form.type" alias="genemu_ajaxdocument" />
-            <argument type="service" id="doctrine.odm.mongodb" />
+            <argument type="service" id="doctrine_mongodb" />
         </service>
     </services>
 


### PR DESCRIPTION
The service IDs for the DoctrineMongoDBBundle have changed for version 2.1. This is an update to reflect that change.

https://github.com/doctrine/DoctrineMongoDBBundle/pull/134
