### PR TITLE
Adds Request declaration in readme files

### DIFF
--- a/Resources/doc/jquery/autocomplete/choices_ajax.md
+++ b/Resources/doc/jquery/autocomplete/choices_ajax.md
@@ -25,6 +25,7 @@ public function buildForm(FormBuilder $builder, array $options)
 namespace MyNamespace;
 
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 

--- a/Resources/doc/jquery/autocomplete/entity_ajax.md
+++ b/Resources/doc/jquery/autocomplete/entity_ajax.md
@@ -27,6 +27,7 @@ public function buildForm(FormBuilder $builder, array $options)
 namespace MyNamespace;
 
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 

--- a/Resources/doc/jquery/autocomplete/mongodb_ajax.md
+++ b/Resources/doc/jquery/autocomplete/mongodb_ajax.md
@@ -36,6 +36,7 @@ public function buildForm(FormBuilder $builder, array $options)
 namespace MyNamespace;
 
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 

--- a/Resources/doc/jquery/autocomplete/propel_ajax.md
+++ b/Resources/doc/jquery/autocomplete/propel_ajax.md
@@ -36,6 +36,7 @@ public function buildForm(FormBuilder $builder, array $options)
 namespace MyNamespace;
 
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 

--- a/Resources/doc/jquery/autocomplete/text_ajax.md
+++ b/Resources/doc/jquery/autocomplete/text_ajax.md
@@ -21,6 +21,7 @@ public function buildForm(FormBuilder $builder, array $options)
 namespace MyNamespace;
 
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 


### PR DESCRIPTION
Adds use Symfony\Component\HttpFoundation\Request; to the ajax examples to make them complete.

The modification of the pull #167 did not work as expected, so here's a new one.
