### PR TITLE
Fix datepicker field id for choice widget

### DIFF
--- a/Resources/views/Form/jquery_layout.html.twig
+++ b/Resources/views/Form/jquery_layout.html.twig
@@ -76,7 +76,6 @@
 
     <script type="text/javascript">
         jQuery(document).ready(function($) {
-            $field = $('#{{ id }}');
         
         {% block genemu_jquerydate_javascript_prototype %}
 
@@ -109,7 +108,7 @@
             }
         {% endif %}
 
-            $field.datepicker($configs);
+            $('#{{ id }}').datepicker($configs);
         {% endblock %}
         });
     </script>


### PR DESCRIPTION
As you change id if widget is not single_text, you must specify the field id after checking it
