### PR TITLE
Fix Fatal Error: Call to a member function getStream() on a non-object

### DIFF
--- a/Twig/Extension/FormExtension.php
+++ b/Twig/Extension/FormExtension.php
@@ -11,16 +11,29 @@
 
 namespace Genemu\Bundle\FormBundle\Twig\Extension;
 
-use Symfony\Bridge\Twig\Extension\FormExtension as BaseFormExtension;
 use Symfony\Component\Form\FormView;
+use Symfony\Bridge\Twig\Form\TwigRendererInterface;
 
 /**
  * FormExtension extends Twig with form capabilities.
  *
  * @author Olivier Chauvel <olivier@generation-multiple.com>
  */
-class FormExtension extends BaseFormExtension
+class FormExtension extends \Twig_Extension
 {
+    /**
+     * This property is public so that it can be accessed directly from compiled
+     * templates without having to call a getter, which slightly decreases performance.
+     *
+     * @var \Symfony\Component\Form\FormRendererInterface
+     */
+    public $renderer;
+
+    public function __construct(TwigRendererInterface $renderer)
+    {
+        $this->renderer = $renderer;
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -35,7 +48,8 @@ class FormExtension extends BaseFormExtension
     /**
      * Render Function Form Javascript
      *
-     * @param FromView $view
+     * @param FormView $view
+     * @param bool $prototype
      *
      * @return string
      */


### PR DESCRIPTION
There are problems when Genemu\Bundle\FormBundle\Twig\Extension\FormExtension extends from Symfony\Bridge\Twig\Extension\FormExtension, because symfony's form extension provides extra TokenParsers. Genemu\Bundle\FormBundle\Twig\Extension\FormExtension must not provides extra token parsers.

Without this change i got error "Fatal Error: Call to a member function getStream() on a non-object in /path/to/symfony/Bridge/Twig/TokenParser/FormThemeTokenParser on line 33"

P.S. Thi is reopened PU https://github.com/genemu/GenemuFormBundle/pull/204 to branch 2.1
