### PR TITLE
resolving 2 issues

### DIFF
--- a/Form/Core/Type/ReCaptchaType.php
+++ b/Form/Core/Type/ReCaptchaType.php
@@ -17,6 +17,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\Form\FormValidatorInterface;
 use Symfony\Component\Form\Exception\FormException;
+use Genemu\Bundle\FormBundle\Form\Core\Validator\ReCaptchaValidator;
 
 /**
  * ReCaptchaType
@@ -33,12 +34,12 @@ class ReCaptchaType extends AbstractType
     /**
      * Constructs
      *
-     * @param FormValidatoInterface $validator
+     * @param ReCaptchaValidator $validator
      * @param string                $pulicKey
      * @param string                $serverUrl
      * @param array                 $options
      */
-    public function __construct(FormValidatorInterface $validator, $publicKey, $serverUrl, array $options)
+    public function __construct(ReCaptchaValidator $validator, $publicKey, $serverUrl, array $options)
     {
         if (true === empty($publicKey)) {
             throw new FormException('The child node "public_key" at path "genemu_form.recaptcha" must be configured.');
@@ -56,6 +57,8 @@ class ReCaptchaType extends AbstractType
     public function buildForm(FormBuilder $builder, array $options)
     {
         $options = $this->getDefaultOptions($options);
+
+        $this->validator->invalidMessage = $options["invalid_message"];
 
         $builder
             ->addValidator($this->validator)
@@ -84,12 +87,13 @@ class ReCaptchaType extends AbstractType
                 'lang' => \Locale::getDefault(),
             )),
             'validator' => array(
-                'host' => 'www.google.com/recaptcha/api',
+                'host' => 'www.google.com',
                 'port' => 80,
-                'path' => '/verify',
+                'path' => '/recaptcha/api/verify',
                 'timeout' => 10,
             ),
             'error_bubbling' => false,
+            'invalid_message' => 'The captcha is not valid.'
         );
 
         return array_replace_recursive($defaultOptions, $options);
@@ -101,5 +105,10 @@ class ReCaptchaType extends AbstractType
     public function getName()
     {
         return 'genemu_recaptcha';
+    }
+
+    public function getParent(array $options)
+    {
+        return 'text';
     }
 }

--- a/Form/Core/Validator/ReCaptchaValidator.php
+++ b/Form/Core/Validator/ReCaptchaValidator.php
@@ -28,6 +28,8 @@ class ReCaptchaValidator implements FormValidatorInterface
     private $request;
     private $privateKey;
 
+    public $invalidMessage;
+
     /**
      * Constructs
      *
@@ -74,7 +76,8 @@ class ReCaptchaValidator implements FormValidatorInterface
         }
 
         if (true !== ($answer = $this->check($datas, $form->getAttribute('option_validator')))) {
-            $error = sprintf('Unable to check the captcha from the server. (%s)', $answer);
+            //$error = sprintf('Unable to check the captcha from the server. (%s)', $answer);
+            $error = $this->invalidMessage ? $this->invalidMessage : 'The captcha is not valid.';
         }
 
         if (false === empty($error)) {


### PR DESCRIPTION
this resolves
https://github.com/genemu/GenemuFormBundle/issues/207
and
https://github.com/genemu/GenemuFormBundle/issues/189
by adding 'invalid_message' option
it also forces recaptcha type to take into account 'label' (and others default) option by adding getParent() method which returns 'text'
