### PR TITLE
The templates that are provided by a bundle should be registered first ....

### DIFF
--- a/DependencyInjection/Compiler/FormPass.php
+++ b/DependencyInjection/Compiler/FormPass.php
@@ -26,12 +26,12 @@ class FormPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        $resources = $container->getParameter('twig.form.resources');
+        $resources = array();
 
         foreach (array('div', 'jquery', 'stylesheet') as $template) {
             $resources[] = 'GenemuFormBundle:Form:' . $template . '_layout.html.twig';
         }
 
-        $container->setParameter('twig.form.resources', $resources);
+        $container->setParameter('twig.form.resources', array_merge($resources, $container->getParameter('twig.form.resources')));
     }
 }


### PR DESCRIPTION
...this allows for template overriding by a custom form template
