### PR TITLE
Fix variable scope for color picker

### DIFF
--- a/Resources/views/Form/jquery_layout.html.twig
+++ b/Resources/views/Form/jquery_layout.html.twig
@@ -136,8 +136,8 @@
 {% spaceless %}
     <script type="text/javascript">
         jQuery(document).ready(function($) {
-            $field = $('#{{ id }}');
-            $configs = $.extend({
+            var $field = $('#{{ id }}');
+            var $configs = $.extend({
                 color: '#' + $field.val(),
                 onBeforeShow: function() {
                     $(this).ColorPickerSetColor($field.val());


### PR DESCRIPTION
This intend to bo conflict when new fields was defined (like datepicker) after color picker where $field variable was no longer the same
