### PR TITLE
Store relative paths in session

### DIFF
--- a/Controller/Base64Controller.php
+++ b/Controller/Base64Controller.php
@@ -25,6 +25,17 @@ class Base64Controller extends ContainerAware
     {
         $captcha = $this->container->get('genemu.gd.captcha');
         $options = $this->container->get('session')->get('genemu_form.captcha.options', array());
+
+        $applicationRootDir = realpath($this->container->get('kernel')->getRootDir() . '/../');
+
+        if (isset($options['fonts'])) {
+            array_walk($options['fonts'], function(&$fontPath) use ($applicationRootDir) {
+                if (strncmp($fontPath, '/', 1)) {
+                    $fontPath = sprintf("%s/%s", $applicationRootDir, $fontPath);
+                }
+            });
+        }
+
         $captcha->setOptions($options);
         $datas = preg_split('([;,]{1})', substr($captcha->getBase64(), 5));
 

--- a/Gd/Type/Captcha.php
+++ b/Gd/Type/Captcha.php
@@ -28,6 +28,7 @@ class Captcha extends Gd
 {
     protected $session;
     protected $secret;
+    protected $applcationRootDir;
     protected $code;
 
     protected $width;
@@ -53,10 +54,11 @@ class Captcha extends Gd
      * @param Session $session
      * @param string  $secret
      */
-    public function __construct(Session $session, $secret)
+    public function __construct(Session $session, $secret, $applicationRootDir)
     {
         $this->session = $session;
         $this->secret = $secret;
+        $this->applcationRootDir = realpath($applicationRootDir) . "/";
         $this->key = 'genemu_form.captcha';
     }
 
@@ -99,6 +101,12 @@ class Captcha extends Gd
 
             $this->$key = $values;
         }
+
+        $applicationRootDirPattern = sprintf("/%s/", addcslashes($this->applcationRootDir, '/'));
+
+        array_walk($options['fonts'], function(&$fontPath) use ($applicationRootDirPattern) {
+            $fontPath = preg_replace($applicationRootDirPattern, "", $fontPath, 1);
+        });
 
         $this->session->set($this->key.'.options', $options);
     }

--- a/Resources/config/imagine.xml
+++ b/Resources/config/imagine.xml
@@ -8,6 +8,7 @@
         <service id="genemu.gd.captcha" class="Genemu\Bundle\FormBundle\Gd\Type\Captcha">
             <argument type="service" id="session" />
             <argument>%kernel.secret%</argument>
+            <argument>%kernel.root_dir%/../</argument>
         </service>
     </services>
 


### PR DESCRIPTION
Store fonts option using relative path and reconstruct it back in refresh captcha action.
