### PR TITLE
Fix language detection in datepicker

### DIFF
--- a/Form/JQuery/Type/DateType.php
+++ b/Form/JQuery/Type/DateType.php
@@ -82,7 +82,7 @@ class DateType extends AbstractType
 
         $resolver
             ->setDefaults(array(
-                'culture' => \Locale::getDefault(),
+                'culture' => \Locale::getPrimaryLanguage(\Locale::getDefault()),
                 'widget' => 'choice',
                 'years'  => range(date('Y') - 5, date('Y') + 5),
                 'configs' => array(


### PR DESCRIPTION
When a full locale is set in project (fr_FR) the default option language is incorrect as it should be 'fr' instead of 'fr_FR' for jquery translation
