### PR TITLE
JQuery bug with no option on genemu_jquerygeolocation

### DIFF
--- a/Form/JQuery/Type/GeolocationType.php
+++ b/Form/JQuery/Type/GeolocationType.php
@@ -56,7 +56,8 @@ class GeolocationType extends AbstractType
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
         $view->vars = array_replace($view->vars, array(
-            'configs' => array('elements' => array()),
+            'configs'   => array(),
+            'elements'  => array(),
             'map' => $options['map']
         ));
     }

--- a/Resources/views/Form/jquery_layout.html.twig
+++ b/Resources/views/Form/jquery_layout.html.twig
@@ -438,44 +438,30 @@
 
 {% block genemu_jquerygeolocation_javascript %}
 {% spaceless %}
+    {# Elements generation #}
     {% if map is sameas(true) %}
-        {% set configs = configs|merge({
-            "elements": configs.elements|merge({
-                "map": "#" ~ id ~ "_map"
-            })
-        }) %}
+        {% set elements = elements|merge({"map": "#" ~ id ~ "_map"}) %}
     {% endif %}
 
     {% if form.latitude is defined %}
-        {% set configs = configs|merge({
-            "elements": configs.elements|merge({
-                "lat": "#" ~ form.latitude.get("id")
-            })
-        }) %}
+        {% set elements = elements|merge({"lat": "#" ~ form.latitude.get("id")}) %}
     {% endif %}
 
     {% if form.longitude is defined %}
-        {% set configs = configs|merge({
-            "elements": configs.elements|merge({
-                "lng": "#" ~ form.longitude.get("id")
-            })
-        }) %}
+        {% set elements = elements|merge({"lng": "#" ~ form.longitude.get("id")}) %}
     {% endif %}
 
     {% if form.locality is defined %}
-        {% set configs = configs|merge({
-            "elements": configs.elements|merge({
-                "locality": "#" ~ form.locality.get("id")
-            })
-        }) %}
+        {% set elements = elements|merge({"locality": "#" ~ form.locality.get("id")}) %}
     {% endif %}
 
     {% if form.country is defined %}
-        {% set configs = configs|merge({
-            "elements": configs.elements|merge({
-                "country": "#" ~ form.country.get("id")
-            })
-        }) %}
+        {% set elements = elements|merge({"country": "#" ~ form.country.get("id")}) %}
+    {% endif %}
+
+    {# Configs generation #}
+    {% if elements | length > 0 %}
+        {% set configs = configs|merge({"elements": elements}) %}
     {% endif %}
 
     <script type="text/javascript">


### PR DESCRIPTION
If you just use jquerygeolocation type with no option (no map, no extra field) like that:

``` php
$form = $this->createFormBuilder()
        ->add('test', 'genemu_jquerygeolocation')
        ->getForm()
;
```

It will produce this js code:

``` javascript
<script type="text/javascript">
    jQuery(document).ready(function($) {
        $field = $('#form_toto_address');

        $field.addresspicker({"elements":[]});

    });
</script>
```

It seems that jQuery dislike this empty array, and it produce a blank page with some js error on chrome:

```
Uncaught TypeError: Cannot call method 'appendChild' of undefined main.js:11
pe main.js:11
ff.(anonymous function).f main.js:18
(anonymous function) main.js:9

Uncaught TypeError: Cannot read property 'firstChild' of null chrome-extension://kkelicaakdanhinjdeammmilcgefonfh/js/jquery.js:35
c.props.for chrome-extension://kkelicaakdanhinjdeammmilcgefonfh/js/jquery.js:35
(anonymous function) chrome-extension://kkelicaakdanhinjdeammmilcgefonfh/js/jquery.js:37
(anonymous function) chrome-extension://kkelicaakdanhinjdeammmilcgefonfh/js/jquery.js:154

Uncaught TypeError: Cannot read property 'style' of null app_dev.php:37
Sfjs.load.window.location app_dev.php:37
(anonymous function) app_dev.php:37
xhr.onreadystatechange app_dev.php:37

Error in event handler for 'undefined': $ is not defined ReferenceError: $ is not defined
    at insertTooltip (chrome-extension://kkelicaakdanhinjdeammmilcgefonfh/js/content.js:57:21)
    at toggleTooltip (chrome-extension://kkelicaakdanhinjdeammmilcgefonfh/js/content.js:33:3)
    at chrome-extension://kkelicaakdanhinjdeammmilcgefonfh/js/content.js:26:2
    at miscellaneous_bindings:286:9
    at chrome.Event.dispatchToListener (event_bindings:387:21)
    at chrome.Event.dispatch_ (event_bindings:373:27)
    at chrome.Event.dispatch (event_bindings:393:17)
    at Object.chromeHidden.Port.dispatchOnMessage (miscellaneous_bindings:253:22) event_bindings:377

Uncaught TypeError: Cannot call method 'appendChild' of undefined main.js:11
pe main.js:11
ff.(anonymous function).f main.js:18
(anonymous function)
```

I simply separated `elements` from `configs` and test if array is not empty, works perfectly for me ! ;)

About configs, this type is not configurable at all, and a lot of new elements can be add as you can see here: https://github.com/sgruhier/jquery-addresspicker/blob/master/demos/index.html

Furthermore, the documentation has to be completed.

I will work on it soon.

Thanks. :)
