### PR TITLE
Fixed jQuery color picker initialization

### DIFF
--- a/Resources/views/Form/jquery_layout.html.twig
+++ b/Resources/views/Form/jquery_layout.html.twig
@@ -160,6 +160,10 @@
         {% if widget == "image" %}
             ${{ id }}_picker = $('#{{ id }}_color');
 
+            $('div', ${{ id }}_picker).css({
+                backgroundColor: ${{ id }}_field.val()
+            });
+
             ${{ id }}_picker.ColorPicker($.extend({
                 onChange: function(hsb, hex, rgb) {
                     ${{ id }}_field.val('#' + hex);


### PR DESCRIPTION
In cases when more than one color picker field is created in one form.
I also added # before hex, when setting a value, because in plugin config https://github.com/genemu/GenemuFormBundle/blob/master/Resources/views/Form/jquery_layout.html.twig#L154 the color was set with #, and that's a correct behavior even for input with type="color".
