### PR TITLE
Replaced the outdated method setVar to set

### DIFF
--- a/Form/JQuery/Type/ImageType.php
+++ b/Form/JQuery/Type/ImageType.php
@@ -58,12 +58,11 @@ class ImageType extends AbstractType
             if ($data->hasThumbnail($this->selected)) {
                 $thumbnail = $data->getThumbnail($this->selected);
 
-                $view
-                    ->set('thumbnail', array(
-                        'file' => $configs['folder'] . '/' . $thumbnail->getFilename(),
-                        'width' => $thumbnail->getWidth(),
-                        'height' => $thumbnail->getHeight(),
-                    ));
+                $view->vars['thumbnail'] = array(
+                    'file' => $configs['folder'] . '/' . $thumbnail->getFilename(),
+                    'width' => $thumbnail->getWidth(),
+                    'height' => $thumbnail->getHeight(),
+                );
             }
 
             $value = $configs['folder'] . '/' . $data->getFilename();


### PR DESCRIPTION
I had the following error:
Fatal error: Call to undefined method Symfony\Component\Form\FormView::setVar() in /private/var/www/sandbox/vendor/genemu/form-bundle/Genemu/Bundle/FormBundle/Form/JQuery/Type/ImageType.php on line 63

fixed: replaced the outdated method setVar to set
