### PR TITLE
 ImageController: We should not add "directory separator" twice on "folder" var

### DIFF
--- a/Controller/ImageController.php
+++ b/Controller/ImageController.php
@@ -27,7 +27,7 @@ class ImageController extends ContainerAware
     {
         $request = $this->container->get('request');
         $rootDir = rtrim($this->container->getParameter('genemu.form.file.root_dir'), '/\\') . DIRECTORY_SEPARATOR;
-        $folder = rtrim($this->container->getParameter('genemu.form.file.folder'), '/\\') . DIRECTORY_SEPARATOR;
+        $folder = rtrim($this->container->getParameter('genemu.form.file.folder'), '/\\');
 
         $file = $request->get('image');
         $handle = new Image($rootDir . $this->stripQueryString($file));


### PR DESCRIPTION
On linux platform we obtain: **myfolder//xxx.png**
On windows platform we obtain: **myfolder\/xxx.png**, and it doesn't work!

We need only **myfolder/xxx.png** in any case
