### PR TITLE
Separate slider configs from options + animate option

### DIFF
--- a/Form/JQuery/Type/SliderType.php
+++ b/Form/JQuery/Type/SliderType.php
@@ -28,7 +28,15 @@ class SliderType extends AbstractType
      */
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
-        $view->vars['configs'] = $options;
+        // Separate slider configs from options
+        $configs = array();
+        foreach (array('min', 'max', 'step', 'orientation', 'animate', 'disabled') as $config) {
+            if (isset($options[$config])) {
+                $configs[$config] = $options[$config];
+            }
+        }
+
+        $view->vars['configs'] = $configs;
     }
 
     public function setDefaultOptions(OptionsResolverInterface $resolver)
@@ -39,15 +47,23 @@ class SliderType extends AbstractType
             'step' => 1,
             'orientation' => 'horizontal'
         ));
-
+        
+        $resolver->setOptional(array(
+            'animate'
+        ));
+        
         $resolver->setAllowedValues(array(
             'orientation' => array(
                 'horizontal',
                 'vertical'
             )
         ));
-    }
 
+        $resolver->setAllowedTypes(array(
+            'animate' => array('string', 'integer', 'bool')
+        ));
+    }
+    
     /**
      * {@inheritdoc}
      */

--- a/Resources/doc/jquery/slider/index.md
+++ b/Resources/doc/jquery/slider/index.md
@@ -12,3 +12,21 @@ public function buildForm(FormBuilder $builder, array $options)
         ->add('price', 'genemu_jqueryslider');
 }
 ```
+
+## With all options:
+``` php
+<?php
+// ...
+public function buildForm(FormBuilder $builder, array $options)
+{
+    $builder
+        // ...
+        ->add('price', 'genemu_jqueryslider', array(
+            'min'           => 0,
+            'max'           => 100,
+            'step'          => 1,
+            'orientation'   => 'horizontal',
+            'animate'       => false
+        ))
+}
+```


### PR DESCRIPTION
Actually, if we use the FormType like this:

``` php
$form = $this->createFormBuilder()
        ->add('price', 'genemu_jqueryslider', array(
            'orientation'   => 'vertical',
            'animate'       => 100,
            'disabled'      => true,
            'data'          => 70,
            'step'          => 10,
        ))
        ->getForm()
        ;
```

It will produce this javascript code:

``` javascript
jQuery(document).ready(function($) {
    var $field = $('#form_price');
    var $configs = $.extend({"block_name":null,"label":null,"attr":[],"translation_domain":null,"data_class":null,"empty_data":{},"trim":true,"required":true,"read_only":false,"max_length":null,"pattern":null,"property_path":null,"mapped":true,"by_reference":true,"error_bubbling":false,"label_attr":[],"virtual":null,"inherit_data":false,"compound":false,"method":"POST","action":"","auto_initialize":true,"validation_groups":null,"error_mapping":[],"validation_constraint":null,"constraints":[],"cascade_validation":false,"invalid_message":"This value is not valid.","invalid_message_parameters":[],"extra_fields_message":"This form should not contain extra fields.","post_max_size_message":"The uploaded file was too large. Please try to upload a smaller file.","csrf_protection":true,"csrf_field_name":"_token","csrf_provider":{},"intention":"unknown","precision":null,"grouping":false,"rounding_mode":2,"min":0,"max":100,"orientation":"vertical","disabled":true,"data":70,"step":10}, {
        value: 70,
        slide: function(event, ui) {
            $field.val(ui.value);
        }
    });

    $('#form_price_slider').slider($configs);
});
```

All the parent integer form type's options are put in the js configs params, and it is... bad. :p

I done a little trick for separate real configs from all the options, and I also add the missing animate option.

I think it is better to separate it into a `configs` option to the resolver no ? But it will cause BC brake...

Futhermore, the slider plugin can manage ranges, but this FormType is an integer type.
Do you think we shall change this type or create an another (that will generate a lot of code duplaction...) ?

Thanks for reading ! :)

Note: I let you merge this to 2.1 branch too ! ;)
