### PR TITLE
Remove FieldType use in genemu_plain (Sf 2.3 crash)

### DIFF
--- a/Form/Core/Type/PlainType.php
+++ b/Form/Core/Type/PlainType.php
@@ -32,7 +32,8 @@ class PlainType extends AbstractType
             'time_format' => null,
             'attr' => array(
                 'class' => $this->getName()
-            )
+            ),
+            'compound' => false,
         ));
     }
 
@@ -77,14 +78,6 @@ class PlainType extends AbstractType
         }
 
         $view->vars['value'] = (string) $value;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getParent()
-    {
-        return 'field';
     }
 
     /**


### PR DESCRIPTION
FieldType is deprecated since Symfony 2.1 and removed in Symfony 2.3
