### PR TITLE
Automatic observer for autocompleter prototype (in collections)

### DIFF
--- a/Form/JQuery/Type/AutocompleterType.php
+++ b/Form/JQuery/Type/AutocompleterType.php
@@ -71,10 +71,12 @@ class AutocompleterType extends AbstractType
         ));
 
         // check if the view is a prototype
-        $view->vars['is_prototype'] = isset($view->parent) && isset($view->parent->parent) && !empty($view->parent->parent->vars['allow_add']);
+        $view->vars['is_prototype'] = (isset($view->parent) && !empty($view->parent->vars['allow_add']))
+            || (isset($view->parent->parent) && !empty($view->parent->parent->vars['allow_add']))
+        ;
         if ($view->vars['is_prototype']) {
             // add a additional unique id for selection of prototypes
-            $view->vars['attr']['data-unique-autocompleter-id'] = md5(uniqid().rand(1000, 9999));
+            $view->vars['attr']['data-autocompleter-id-hash'] = md5($view->vars['id']);
         }
 
         // Adds a custom block prefix

--- a/Resources/views/Form/jquery_layout.html.twig
+++ b/Resources/views/Form/jquery_layout.html.twig
@@ -250,14 +250,14 @@
 {% spaceless %}
     <script type="text/javascript">
         {% if is_prototype %}
-            {% set selector = ':input[data-unique-autocompleter-id="' ~ attr['data-unique-autocompleter-id'] ~ '"]' %}
+            {% set selector = ':input[data-autocompleter-id-hash="' ~ attr['data-autocompleter-id-hash'] ~ '"]' %}
             jQuery('body').on('focus', '{{ selector | raw }}:visible', function() {
                 var $field = $('#' + this.id.substr('autocompleter_'.length));
                 var $autocompleter = $(this);
                 genemu_jqueryautocompleter_observer_{{ id }}($autocompleter, $field);
 
                 // remove unique-id so that autocomplete is not applied multiple
-                $autocompleter.removeAttr('data-unique-autocompleter-id');
+                $autocompleter.removeAttr('data-autocompleter-id-hash');
             });
         {% else %}
             jQuery(document).ready(function($) {


### PR DESCRIPTION
Hi.
I wrote a patch for automatic observing of _autocompleters_ if they are generated from prototypes of collections. Because it is a little bit annoying if you always have to write extra code for such cases.

`jQuery.on()` is used to observe autocompleters which are generated dynamically from prototypes. Performance impacts should be very low (see http://www.brentsowers.com/2012/03/jquery-on-performance.html).

There's only one problem: This patch will generate javascript code for every prototype fields (not only for autocompleters). But I do not know how to achieve that :-( maybe someone has a better idea.
