### PR TITLE
Support of config.content_css URI

### DIFF
--- a/Form/Core/Type/TinymceType.php
+++ b/Form/Core/Type/TinymceType.php
@@ -16,6 +16,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\Templating\Helper\CoreAssetsHelper;
 
 /**
  * TinymceType
@@ -24,6 +25,7 @@ use Symfony\Component\OptionsResolver\OptionsResolverInterface;
  */
 class TinymceType extends AbstractType
 {
+    private $assetsHelper;
     private $options;
 
     /**
@@ -31,8 +33,9 @@ class TinymceType extends AbstractType
      *
      * @param array $options
      */
-    public function __construct(array $options)
+    public function __construct(CoreAssetsHelper $assetsHelper, array $options)
     {
+        $this->assetsHelper = $assetsHelper;
         $this->options = $options;
     }
 
@@ -42,6 +45,19 @@ class TinymceType extends AbstractType
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
         $view->vars['configs'] = $options['configs'];
+
+        if (isset($view->vars['configs']['script_url'])) {
+            $view->vars['configs']['script_url'] = $this->assetsHelper->getUrl($view->vars['configs']['script_url']);
+        } else {
+            $view->vars['configs']['mode'] = 'exact';
+            $view->vars['configs']['elements'] = $view->vars['id'];
+        }
+
+        if (isset($view->vars['configs']['content_css']) && is_array($view->vars['configs']['content_css'])) {
+            foreach ($view->vars['configs']['content_css'] as $index => $path) {
+                $view->vars['configs']['content_css'][$index] = $this->assetsHelper->getUrl($path);
+            }
+        }
     }
 
     /**

--- a/Resources/config/form.xml
+++ b/Resources/config/form.xml
@@ -38,8 +38,9 @@
         <service id="genemu.form.core.type.plain" class="Genemu\Bundle\FormBundle\Form\Core\Type\PlainType">
             <tag name="form.type" alias="genemu_plain" />
         </service>
-        <service id="genemu.form.core.type.tinymce" class="Genemu\Bundle\FormBundle\Form\Core\Type\TinymceType">
+        <service id="genemu.form.core.type.tinymce" class="Genemu\Bundle\FormBundle\Form\Core\Type\TinymceType" scope="request">
             <tag name="form.type" alias="genemu_tinymce" />
+            <argument type="service" id="templating.helper.assets"/>
             <argument>%genemu.form.tinymce.configs%</argument>
         </service>
     </services>

--- a/Resources/views/Form/jquery_layout.html.twig
+++ b/Resources/views/Form/jquery_layout.html.twig
@@ -50,17 +50,6 @@
 
 {% block genemu_tinymce_javascript %}
 {% spaceless %}
-    {% if configs.script_url is defined %}
-        {% set configs = configs|merge({
-            "script_url": asset(configs.script_url)
-        }) %}
-    {% else %}
-        {% set configs = configs|merge({
-            "mode": "exact",
-            "elements": id
-        }) %}
-    {% endif %}
-
     <script type="text/javascript">
         jQuery(document).ready(function($) {
             var $configs = {{ configs|json_encode|raw }};


### PR DESCRIPTION
I have improved two things:
- Transform paths in `configs.content_css` to URIs
- Transform path in `configs.script_url` in `TinymceType`not in template

@bamarni could you merge this PR ?
