### PR TITLE
Support of ButtonType

### DIFF
--- a/Resources/views/Form/jquery_layout.html.twig
+++ b/Resources/views/Form/jquery_layout.html.twig
@@ -8,6 +8,8 @@
 
 {% block field_javascript "" %}
 
+{% block button_javascript "" %}
+
 {% block genemu_captcha_javascript %}
 {% spaceless %}
     <!--[if lte IE 7]>

--- a/Resources/views/Form/stylesheet_layout.html.twig
+++ b/Resources/views/Form/stylesheet_layout.html.twig
@@ -8,6 +8,8 @@
 
 {% block field_stylesheet "" %}
 
+{% block button_stylesheet "" %}
+
 {% block genemu_jquerycolor_stylesheet %}
 {% spaceless %}
 {% if widget == "image" %}


### PR DESCRIPTION
Symfony 2.3 added the ButtonType in form. It generate a
Twig_Error_Runtime exception when using form_javascript and/or
from_stylesheet cause there is no button_javascript or
button_stylesheet.
Add them.
