### PR TITLE
Add the 'range' parameter to the slider element

### DIFF
--- a/Form/JQuery/Type/SliderType.php
+++ b/Form/JQuery/Type/SliderType.php
@@ -38,7 +38,6 @@ class SliderType extends AbstractType
             'max' => 100,
             'step' => 1,
             'range' => true,
-            'minRange' => 0,
             'orientation' => 'horizontal'
         ));
 


### PR DESCRIPTION
Hello,

As I was trying to set a slider into my form using this library, I found that the 'range' parameter was not handled.

So here is the 'range' parameter just added.

For the 'range' parameter, allowed values are TRUE or FALSE. Feel free to add any allowed values if you find an utility.
