### PR TITLE
Fallback to Symfony's default 'required' option in RatingType

### DIFF
--- a/Form/JQuery/Type/RatingType.php
+++ b/Form/JQuery/Type/RatingType.php
@@ -40,6 +40,9 @@ class RatingType extends AbstractType
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
         $view->vars['configs'] = $form->getConfig()->getAttribute('configs');
+        if (!isset($view->vars['configs']['required'])) {
+            $view->vars['configs']['required'] = $options['required'];
+        }
     }
 
     /**


### PR DESCRIPTION
Fallback to Symfony's default 'required' option if not has been set in 'config' of RatingType.

Otherwise it is a bit confusing if you set 'required' to false but nothing happens.

``` php
<?php
// ...
public function buildForm(FormBuilder $builder, array $options)
{
    $builder
        // ...
        ->add('rating', 'genemu_jqueryrating', array(
            'required' => false, // now this is enough
            'configs' => array(
                'required' => false, // without the patch this line is needed
            )
        ))
}
```
