### PR TITLE
Automatic observer for autocompleter prototype (in collections)

### DIFF
--- a/Form/JQuery/Type/AutocompleterType.php
+++ b/Form/JQuery/Type/AutocompleterType.php
@@ -70,6 +70,13 @@ class AutocompleterType extends AbstractType
             'free_values' => $options['free_values'],
         ));
 
+        if ((isset($view->parent) && !empty($view->parent->vars['allow_add']))
+            || (isset($view->parent->parent) && !empty($view->parent->parent->vars['allow_add']))
+        ) {
+            // add a additional unique id for selection of prototypes
+            $view->vars['attr']['data-autocompleter-id-hash'] = md5($view->vars['id']);
+        }
+
         // Adds a custom block prefix
         array_splice(
             $view->vars['block_prefixes'],

--- a/Resources/views/Form/jquery_layout.html.twig
+++ b/Resources/views/Form/jquery_layout.html.twig
@@ -246,9 +246,19 @@
 {% block genemu_jqueryautocompleter_javascript %}
 {% spaceless %}
     <script type="text/javascript">
-        jQuery(document).ready(function($) {
-            var $field = $('#{{ id }}');
-            var $autocompleter = $('#autocompleter_{{ id }}');
+        {% if attr['data-autocompleter-id-hash'] is defined %}
+            {% set selector = ':input[data-autocompleter-id-hash="' ~ attr['data-autocompleter-id-hash'] ~ '"]' %}
+            jQuery('body').on('focus', '{{ selector | raw }}:visible', function() {
+                var $field = $('#' + this.id.substr('autocompleter_'.length));
+                var $autocompleter = $(this);
+
+                // remove unique-id so that autocomplete is not applied multiple
+                $autocompleter.removeAttr('data-autocompleter-id-hash');
+        {% else %}
+            jQuery(document).ready(function($) {
+                var $field = $('#{{ id }}');
+                var $autocompleter = $('#autocompleter_{{ id }}');
+        {% endif %}
             var $configs = {
                 focus: function(event, ui) {
                     return false;


### PR DESCRIPTION
Hi.
I rewrote [my patch](https://github.com/genemu/GenemuFormBundle/pull/273) for automatic observing of _autocompleters_ if they are generated from prototypes of collections. Because it was not very clean.

To render the javascript for the autocompleter you just have to insert something like 

``` jinja
    {{ form_javascript(form.emails.vars.prototype) }}
```

into your twig template.
