### PR TITLE
Error in autoComplete multiple with new version of jqueryUi

### DIFF
--- a/Resources/views/Form/jquery_layout.html.twig
+++ b/Resources/views/Form/jquery_layout.html.twig
@@ -302,7 +302,7 @@
             {% endif %}
 
             {% if multiple %}
-                var $source = $autocompleter.data('autocomplete').source;
+                var $source = $autocompleter.data('ui-autocomplete').source;
 
                 $autocompleter.autocomplete('option', 'source', function(request, response) {
                     request.term = request.term.split(/,\s*/).pop();


### PR DESCRIPTION
In my application I got an error with autocomplete multiple type since I started using jqueryUI v1.10.3 and jquery v1.10.1
"
TypeError: $autocompleter.data(...) is undefined
var $source = $autocompleter.data('autocomplete').source;
"
I found in source example on http://jqueryui.com  that "ui-autocomplete" replace "autocomplete".
