### PR TITLE
Allow language option to be overwritten by application config

### DIFF
--- a/Form/Core/Type/TinymceType.php
+++ b/Form/Core/Type/TinymceType.php
@@ -49,9 +49,10 @@ class TinymceType extends AbstractType
      */
     public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
-        $configs = array_merge($this->options, array(
+        $configs = array_merge(array(
             'language' => \Locale::getDefault(),
-        ));
+        ),
+		$this->options);
 
         $resolver
             ->setDefaults(array(


### PR DESCRIPTION
Currently the language if forced to the result of \Locale::getDefault(), but some languages don't have translations for TinyMCE yet. If a translation is not available, the TinyMCE editor isn't rendered. It's therefore crucial that the application's developer can override the language option for the TinyMCE editor
