### PR TITLE
[fix][major] Using non-existent FormException

### DIFF
--- a/Form/Core/Validator/ReCaptchaValidator.php
+++ b/Form/Core/Validator/ReCaptchaValidator.php
@@ -42,7 +42,7 @@ class ReCaptchaValidator implements EventSubscriberInterface
 
         if (empty($options['code'])) {
             if (empty($privateKey)) {
-                throw new InvalidConfigurationException('The child node "private_key" at path "genenu_form.captcha" must be configured.');
+                throw new InvalidConfigurationException('The child node "private_key" at path "genenu_form.recaptcha" must be configured.');
             }
 
             $this->request = $request;


### PR DESCRIPTION
Hi,

In `ReCaptcha` validator, we're using `FormException`, which is unfindable (maybe it was removed in Symfony 2.3?).

This issue fixes it, using a more appropriate `InvalidConfigurationException`. It's quite critical, as `ReCaptcha` is unusable at the moment.

Regards,
