### PR TITLE
cache control

### DIFF
--- a/Controller/Base64Controller.php
+++ b/Controller/Base64Controller.php
@@ -28,7 +28,11 @@ class Base64Controller extends ContainerAware
         $captcha->setOptions($options);
         $datas = preg_split('([;,]{1})', substr($captcha->getBase64(), 5));
 
-        return new Response(base64_decode($datas[2]), 200, array('Content-Type' => $datas[0]));
+        return new Response(base64_decode($datas[2]), 200, array(
+            'Content-Type' => $datas[0],
+            'Cache-Control' => 'no-cache, no-store, must-revalidate',
+            'Pragma' => 'no-cache',
+            'Expires' => 0));
     }
 
     public function base64Action()

--- a/Resources/doc/captcha_gd/index.md
+++ b/Resources/doc/captcha_gd/index.md
@@ -40,7 +40,7 @@ genemu_base64:
         $(function () {
             {# Image will be refreshed when the link is clicked #}
             $('#{{ id }}_refresh').click(function() {
-                $('#{{ id }}_image').attr('src', '{{ path('genemu_captcha_refresh') }}?' + Math.random());
+                $('#{{ id }}_image').attr('src', '{{ path('genemu_captcha_refresh') }}');
             });
         });
     </script>


### PR DESCRIPTION
In order to refresh the captcha, the example given create a sort of unique url using unused random parameter:

```
'{{ path('genemu_captcha_refresh') }}?' + Math.random()
```
It will be cleaner to set correct HTTP response headers rather than using such a hack.
Here is a small patch that should do the trick. Not sure it will work for every web browser.
It is an assumed copy-paste from http://stackoverflow.com/questions/49547/making-sure-a-web-page-is-not-cached-across-all-browsers

It also moves the cache control from client-side to server-side.