### PR TITLE
Fix bug when intl extension is not installed

### DIFF
--- a/Form/JQuery/Type/DateType.php
+++ b/Form/JQuery/Type/DateType.php
@@ -79,10 +79,16 @@ class DateType extends AbstractType
     public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
         $configs = $this->options;
-
+        
+        try {
+            $culture = \Locale::getPrimaryLanguage(\Locale::getDefault());
+        } catch (\Symfony\Component\Intl\Exception\MethodNotImplementedException $e) {
+            $culture = \Locale::getDefault();
+        }
+        
         $resolver
             ->setDefaults(array(
-                'culture' => \Locale::getPrimaryLanguage(\Locale::getDefault()),
+                'culture' => $culture,
                 'widget' => 'choice',
                 'years'  => range(date('Y') - 5, date('Y') + 5),
                 'configs' => array(


### PR DESCRIPTION
If a server has not the php intl extension, symfony use symfony/intl as
a replacement layer, it works only for english language and do not
implement all intl's features.
In this case, DateType call `\Locale::getPrimaryLanguage()` and throw an
Exception. This commit prevent this Exception.
