### PR TITLE
Using translation keys in recaptcha validator

### DIFF
--- a/Form/Core/Validator/ReCaptchaValidator.php
+++ b/Form/Core/Validator/ReCaptchaValidator.php
@@ -85,12 +85,12 @@ class ReCaptchaValidator implements EventSubscriberInterface
 
         if (empty($this->options['code'])) {
             if (empty($datas['challenge']) || empty($datas['response'])) {
-                $error = 'The captcha is not valid.';
+                $error = 'genemu_form.recaptcha.incorrect-captcha-sol';
             } elseif (true !== ($answer = $this->check($datas, $form->getConfig()->getAttribute('option_validator')))) {
-                $error = sprintf('Unable to check the captcha from the server. (%s)', $answer);
+                $error = 'genemu_form.recaptcha.unable-to-check-the-captcha-from-the-server';
             }
         } elseif ($this->options['code'] != $datas['response']) {
-            $error = "The captcha is not valid.";
+            $error = "genemu_form.recaptcha.incorrect-captcha-sol";
         }
 
         if (!empty($error)) {

--- a/Resources/translations/validators.de.yml
+++ b/Resources/translations/validators.de.yml
@@ -2,3 +2,4 @@ genemu_form:
     recaptcha:
         incorrect-captcha-sol: Der angegebene Captcha ist nicht korrekt.
         invalid-site-private-key: Der 'private key' ist nicht korrekt.
+        unable-to-check-the-captcha-from-the-server: Captcha vom Server zu überprüfen.

--- a/Resources/translations/validators.en.yml
+++ b/Resources/translations/validators.en.yml
@@ -2,3 +2,4 @@ genemu_form:
     recaptcha:
         incorrect-captcha-sol: The captcha is invalid.
         invalid-site-private-key: The private key is invalid.
+        unable-to-check-the-captcha-from-the-server: Unable to check the captcha from the server.

--- a/Resources/translations/validators.fr.yml
+++ b/Resources/translations/validators.fr.yml
@@ -2,5 +2,6 @@ The captcha is invalid.: Le captcha est invalide.
 
 genemu_form:
     recaptcha:
-        incorrect-captcha-sol: Le captcha n'est pas valide.
+        incorrect-captcha-sol: "Le captcha n'est pas valide."
         invalid-site-private-key: La clé privée est invalide.
+        unable-to-check-the-captcha-from-the-server: Impossible de vérifier le captcha depuis le serveur.


### PR DESCRIPTION
As multiple users seems to have the same problem I described in #343 here is the PR.

Maybe I should also do PRs for the 2.0 and 2.1 branches ?

Also I do not speak German so if someone could verify my german translation from Google Translate ;)
