### PR TITLE
Added localization for datepicker

### DIFF
--- a/Resources/views/Form/jquery_layout.html.twig
+++ b/Resources/views/Form/jquery_layout.html.twig
@@ -100,6 +100,12 @@
             }) %}
         {% endif %}
 
+        {% if configs.buttonText is defined %}
+            {% set configs = configs|merge({
+                "buttonText": (configs.buttonText | trans)
+            }) %}
+        {% endif %}
+
         {% if culture == "en" %}
             {% set culture = "en-GB" %}
         {% endif %}


### PR DESCRIPTION
DatePicker plugin features an option for including text to display on the trigger button: "buttonText".
Since it would be nice if it were possible to have this message to change when varying users' locale, I added translation filter to the configuration passed from config.yml file. 

Usage:
# app/config/config.yml

```
date: 
    enabled: true
    configs:
        buttonText: mydate_jquery_text
```
# message.en.yml

```
mydate_jquery_text: "Select a Date"
```

Hope this will be useful.
