### PR TITLE
Remove minimum-stability from composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
             "homepage": "https://github.com/genemu/GenemuFormBundle/contributors"
         }
     ],
-    "minimum-stability": "dev",
     "require": {
         "php": ">=5.3.2",
         "symfony/framework-bundle": "~2.6",


### PR DESCRIPTION
I think `minimum-stability` option should be on project config, not bundle.

This PR propose to remove it.