### PR TITLE
Update jquery_layout.html.twig

### DIFF
--- a/Resources/views/Form/jquery_layout.html.twig
+++ b/Resources/views/Form/jquery_layout.html.twig
@@ -137,6 +137,7 @@
                 value: {{ value ? value : 0 }},
                 slide: function(event, ui) {
                     $field.val(ui.value);
+                    $field.trigger('change');
                 }
             });
 


### PR DESCRIPTION
hi, 
Actually, any event is fired when we slide. Adding this line will fire an event when the slider value will change, allowing easiest customisation like displaying a box with the slided value... 

On jquery doc: "Changing the value of an input element using JavaScript, using .val() for example, won't fire the event."