### PR TITLE
Fix for Symfony 3.4.0

### DIFF
--- a/Twig/Extension/FormExtension.php
+++ b/Twig/Extension/FormExtension.php
@@ -12,7 +12,7 @@
 namespace Genemu\Bundle\FormBundle\Twig\Extension;
 
 use Symfony\Component\Form\FormView;
-use Symfony\Bridge\Twig\Form\TwigRendererInterface;
+use Symfony\Component\Form\FormRendererInterface;
 
 /**
  * FormExtension extends Twig with form capabilities.
@@ -32,9 +32,9 @@ class FormExtension extends \Twig_Extension
     /**
      * Constructs.
      *
-     * @param TwigRendererInterface $renderer
+     * @param FormRendererInterface $renderer
      */
-    public function __construct(TwigRendererInterface $renderer)
+    public function __construct(FormRendererInterface $renderer)
     {
         $this->renderer = $renderer;
     }


### PR DESCRIPTION
TwigRendererInterface is deprecated. Symfony 3.4.0 doesn't use it anymore, so an error is thrown when calling this constructor.