### PR TITLE
Fixed Javascript Pattern of jQuery/DateType (needed for PHP 7.3)

### DIFF
--- a/Form/JQuery/Type/DateType.php
+++ b/Form/JQuery/Type/DateType.php
@@ -127,7 +127,7 @@ class DateType extends AbstractType
     protected function getJavascriptPattern(\IntlDateFormatter $formatter)
     {
         $pattern = $formatter->getPattern();
-        $patterns = preg_split('([\\\/.:_;,\s-\ ]{1})', $pattern);
+        $patterns = preg_split('([\\\/.:_;,\s\-\ ]{1})', $pattern);
         $exits = array();
 
         // Transform pattern for JQuery ui datepicker


### PR DESCRIPTION
Since PHP 7.3 the regular expression `([\\\/.:_;,\s-\ ]{1})` triggers the warning `preg_split(): Compilation failed: invalid range in character class at offset 11`. The range operator '-' has to be escaped, because `\s-\ ` is not a valid range.